### PR TITLE
Implement banana browser share link page

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -4,3 +4,64 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
+body,html {
+    margin: 0;
+    padding: 0;
+}
+
+.bannerLabel {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+}
+
+.bannerContent {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.bannerIconShadow {
+    display: flex;
+    align-items: center;
+    filter: drop-shadow(0px 5px 10px rgba(0,0,0,0.1)) drop-shadow(0px 1px 1px rgba(0,0,0,0.2));
+}
+
+.bannerContainer {
+    height: 100vh;
+    overflow-y: hidden;
+    display: flex;
+    align-items: center;
+}
+
+.bannerIconLarge {
+    width: 120px;
+    height: 120px;
+    -webkit-clip-path: url(#shape120);
+    clip-path: url(#shape120);
+}
+
+.bannerNameContainer {
+    display: flex;
+    flex: 0 1 auto;
+    flex-direction: column;
+    align-items: start;
+    justify-content: center;
+    margin-left: 1rem;
+}
+
+.bannerName {
+    color: black;
+    font-size: 1.8rem;
+}
+
+.bannerDescription {
+    color: black;
+    font-weight: normal;
+    margin-top: 13px;
+    font-size: 1.2rem;
+    line-height: 1.5rem;
+}
+
+h1 {
+    margin-block-end: 0em;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,5 +4,28 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
-<p>Triple Banana Browser Share Link</p>
+<div class="bannerContainer" (click)="onBannerClick()">
+  <div class="bannerContent">
+    <div class="bannerIconShadow">
+      <svg width="0" height="0">
+        <defs>
+          <clipPath id="shape120">
+            <path id="shape" class="cls-1"
+              d="M6821,495.533v-4.281c0-1.2-.04-2.4-0.04-3.642a57.7,57.7,0,0,0-.68-7.882,26.144,26.144,0,0,0-2.48-7.483,25.115,25.115,0,0,0-11.04-11.044,26.118,26.118,0,0,0-7.49-2.481,47.28,47.28,0,0,0-7.88-.68c-1.2-.04-2.4-0.04-3.64-0.04h-53.5c-1.2,0-2.4.04-3.64,0.04a57.813,57.813,0,0,0-7.88.68,26.323,26.323,0,0,0-7.49,2.481,25.115,25.115,0,0,0-11.04,11.044,26.144,26.144,0,0,0-2.48,7.483,47.313,47.313,0,0,0-.68,7.882c-0.04,1.2-.04,2.4-0.04,3.642v53.5c0,1.2.04,2.4,0.04,3.641a57.7,57.7,0,0,0,.68,7.883,26.137,26.137,0,0,0,2.48,7.482,25.115,25.115,0,0,0,11.04,11.044,26.261,26.261,0,0,0,7.49,2.481,47.28,47.28,0,0,0,7.88.68c1.2,0.04,2.4.04,3.64,0.04h53.5c1.2,0,2.4-.04,3.64-0.04a57.654,57.654,0,0,0,7.88-.68,26.057,26.057,0,0,0,7.49-2.481,25.115,25.115,0,0,0,11.04-11.044,26.137,26.137,0,0,0,2.48-7.482,47.316,47.316,0,0,0,.68-7.883c0.04-1.2.04-2.4,0.04-3.641V495.533h0Z"
+              transform="translate(-6701 -458)" filter="url(#f1)">
+            </path>
+          </clipPath>
+        </defs>
+      </svg>
+      <img class="bannerIconLarge" src="assets/app_icon.svg">
+    </div>
+    <div class="bannerNameContainer">
+      <h1 class="bannerName bannerLabel">
+        Banana Browser
+      </h1>
+      <h2 class="bannerDescription bannerLabel">
+        {{bannerDescription}}
+      </h2>
+    </div>
+  </div>
+</div>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -14,4 +14,123 @@ describe('AppComponent', () => {
       ],
     }).compileComponents();
   });
+
+  const TRIPLE_BANANA_SHARE_URL = "https://triplebanana.dev/share"
+
+  const USER_AGENT_ANDROID_CHROME_BROWSER =
+    "Mozilla/5.0 (Linux; Android 12; SM-G996N) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Mobile Safari/537.36"
+  const USER_AGENT_ANDROID_KAKAOTALK_WEB_VIEW =
+    "Mozilla/5.0 (Android; Mobile; rv:13.0) \
+    Gecko/13.0 Firefox/13.0 KAKAOTALK"
+
+  const USER_AGENT_LINUX_CHROME =
+    "Mozilla/5.0 (X11; Linux x86_64) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"
+
+  it('should move android intent including target url when use chrome browser', fakeAsync(() => {
+    // given
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+
+    const shareUrl = "https://google.com"
+    spyOn<any>(app, 'getCurrentUrl').and.returnValue(generateShareLink(shareUrl))
+    const moveToUrl = spyOn<any>(app, 'moveToUrl')
+    spyOnProperty(navigator, 'userAgent').and.returnValue(USER_AGENT_ANDROID_CHROME_BROWSER)
+
+    // when
+    fixture.detectChanges()
+    tick()
+
+    // then
+    const calledIntent = new URL(moveToUrl.calls.mostRecent().args[0] as string)
+    expect(calledIntent.protocol).toEqual("intent:")
+    expect(calledIntent.pathname.includes("google.com")).toBeTruthy()
+  }));
+
+  it('should move android intent including \
+    target url when use not chrome browser via iframe', fakeAsync(() => {
+    // given
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+
+    const shareUrl = "https://google.com"
+
+    spyOn<any>(app, 'getCurrentUrl').and.returnValue(generateShareLink(shareUrl))
+
+    const moveToUrlWithIframe = spyOn<any>(app, 'moveToUrlWithIframe')
+      .and.callFake((url: string): void => console.log("do not move for test"))
+
+    const moveToUrl = spyOn<any>(app, 'moveToUrl')
+      .and.callFake((url: string) => console.log("do not move for test"))
+
+    spyOnProperty(navigator, 'userAgent')
+      .and.returnValue(USER_AGENT_ANDROID_KAKAOTALK_WEB_VIEW)
+
+    // when
+    fixture.detectChanges()
+    tick()
+
+    // then
+    expect(moveToUrlWithIframe).toHaveBeenCalled()
+
+    // after few time, means failed to move with intent then should move to playstore
+    tick(app.DEFAULT_WAIT_TIME_MS)
+
+    const playStoreUrl = moveToUrl.calls.mostRecent().args[0]
+    expect(moveToUrl).toHaveBeenCalled()
+    expect(playStoreUrl).toEqual(`${app.PLAYSTORE_URL}?id=${app.PACKAGE_ID}`)
+  }));
+
+  it('should just move to target url if not android platform', fakeAsync(() => {
+    // given
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+
+    const shareUrl = new URL("https://google.com")
+
+    spyOn<any>(app, 'getCurrentUrl').and.returnValue(generateShareLink(shareUrl.toString()))
+
+    spyOnProperty(navigator, 'userAgent')
+      .and.returnValue(USER_AGENT_LINUX_CHROME)
+
+    const moveToUrl = spyOn<any>(app, 'moveToUrl')
+
+    // when
+    fixture.detectChanges()
+    tick()
+
+    // then
+    const moveUrl = new URL(moveToUrl.calls.mostRecent().args[0] as string)
+    expect(moveUrl.protocol).toEqual(shareUrl.protocol)
+    expect(moveUrl.pathname).toEqual(shareUrl.pathname)
+  }));
+
+  it('should move to banana dev page if invalid sharelink', fakeAsync(() => {
+    // given
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+
+    // shareUrl without "shareLink" param
+    const shareUrl = window.location.toString()
+    spyOn<any>(app, 'getCurrentUrl').and.returnValue(shareUrl)
+
+    const moveToUrl = spyOn<any>(app, 'moveToUrl')
+
+    // when
+    fixture.detectChanges()
+    tick()
+
+    // then
+    const moveUrl = moveToUrl.calls.mostRecent().args[0] as URL
+    expect(moveUrl.toString()).toEqual(app.TRIPLE_BANANA_DEV_URL)
+  }));
+
+  function generateShareLink(url: string) {
+    return `${TRIPLE_BANANA_SHARE_URL}?sharelink=${url}`
+  }
+
+  function assertCalledIntent(intent: string, expectedUrl: string) {
+
+  }
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,13 +3,116 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
-  title = 'ShareLink';
+export class AppComponent implements OnInit {
+  readonly DEFAULT_BANNER_DESCRIPTION: string = "Safer, faster, and more stable"
+  readonly ANDROID_CHROME_CLICK_DESCRIPTION = "Click to open link with Banana browser"
+
+  readonly PACKAGE_ID = "org.triple.banana"
+  readonly DEFAULT_WAIT_TIME_MS = 300
+
+  readonly TRIPLE_BANANA_DEV_URL = "https://triplebanana.dev"
+  readonly PLAYSTORE_URL = "https://play.google.com/store/apps/details"
+
+  bannerDescription = this.DEFAULT_BANNER_DESCRIPTION
+
+  private targetUrl: URL = new URL(this.TRIPLE_BANANA_DEV_URL)
+  private targetUrlOnly: string = ""
+
+  ngOnInit(): void {
+    this.processShareLink()
+  }
+
+  onBannerClick() {
+    this.gotoLinkOrStore(this.targetUrlOnly)
+  }
+
+  private processShareLink() {
+    const linkTo = this.getLinkToUrl()
+
+    if (!linkTo) {
+      console.error("Failed to parse banana link : " + window.location.toString())
+      this.moveToUrl(this.TRIPLE_BANANA_DEV_URL)
+      return
+    }
+    this.targetUrl = linkTo
+
+    this.targetUrlOnly = linkTo.toString().substring(linkTo.protocol.length + "//".length)
+    this.gotoLinkOrStore(this.targetUrlOnly)
+  }
+
+  private gotoLinkOrStore(url: string) {
+    const userAgent = this.getUserAgent();
+    console.log(userAgent)
+    if (userAgent.match(/Android/)) {
+      if (userAgent.match(/Chrome/)) {
+        this.handleChromium(url)
+      } else {
+        this.handleOtherBrowsers(url)
+      }
+    }
+    else {
+      this.moveToUrl(this.targetUrl.toString())
+    }
+  }
+
+  private getLinkToUrl(): URL | null {
+    const currentURL = new URL(this.getCurrentUrl())
+    const bananaLink = currentURL.searchParams.get('sharelink')
+    if (!bananaLink) {
+      return null
+    }
+    return new URL(bananaLink)
+  }
+
+  private handleChromium(url: string) {
+    this.bannerDescription = this.ANDROID_CHROME_CLICK_DESCRIPTION
+    this.moveToUrl(this.generateAndroidChromIntent(url, this.PACKAGE_ID))
+  }
+
+  private handleOtherBrowsers(url: string) {
+    setTimeout(() => {
+        this.moveToUrl(this.generatePlayStoreLinkUrl(this.PACKAGE_ID))
+    }, this.DEFAULT_WAIT_TIME_MS)
+
+    this.moveToUrlWithIframe(url)
+  }
+
+  private moveToUrlWithIframe(url: string): void {
+    const iframe = document.createElement('iframe')
+    iframe.style.visibility = 'hidden'
+    iframe.src = this.generateAndroidIntent(url, this.PACKAGE_ID)
+    document.body.appendChild(iframe);
+    document.body.removeChild(iframe);
+  }
+
+  private generateAndroidChromIntent(url: string, packageId: string): string {
+    return `intent://${url}#Intent;scheme=http;package=${packageId};end`
+  }
+
+  private moveToUrl(url: string) {
+    location.href = url
+  }
+
+  private getCurrentUrl() {
+    return location.href
+  }
+
+  private getUserAgent(): string {
+    return navigator.userAgent
+  }
+
+  private generateAndroidIntent(url: string, packageId: string): string {
+    return `intent://${url}#Intent;scheme=http;package=${packageId};S.browser_fallback_url=${url};action=android.intent.action.VIEW;end;`
+  }
+
+  private generatePlayStoreLinkUrl(packageId: string) {
+    return `${this.PLAYSTORE_URL}?id=${packageId}`
+  }
 }

--- a/src/assets/app_icon.svg
+++ b/src/assets/app_icon.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="레이어_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#FFE11C;}
+</style>
+<g>
+	<g>
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="0.4479" y1="-0.1108" x2="512.4479" y2="511.8892">
+			<stop  offset="0" style="stop-color:#5058CB"/>
+			<stop  offset="0.5" style="stop-color:#551DCB"/>
+			<stop  offset="1" style="stop-color:#7D1DCB"/>
+		</linearGradient>
+		<rect x="0.4" y="-0.1" class="st0" width="512" height="512"/>
+	</g>
+	<g id="JskLhw_26_">
+		<g>
+			<path class="st1" d="M137.5,237.1c10.8,66.3,63.6,86.2,88.1,93c24.5,6.8,28.7-7.6,20.8-20.3c-32.8-65-43.7-116,1.5-207.5
+				c9.6-12,11.4-32.5-7.3-37.9c-6.5-1.8-26.4-7-25.7,14c0.3,8.3,2.3,13.3-10.2,25.6C161.4,145.9,132.3,183.4,137.5,237.1z"/>
+			<path class="st1" d="M416.8,359.7c17.3-20.2,9.9-36.5-11.7-27.4c-47,22.5-95.6,30.4-135.6,28.3c-65-3.6-108.3-24.7-156-64.8
+				c-16.4-12.2-31.7,0.6-25.1,15.8c5.2,10.6,8.5,8.1,14.3,19.5c5.2,10.1,8.1,18.1,18,32.8c16.7,24.9,37.8,43,62.2,56.1
+				C238.1,445.5,337.7,451.2,416.8,359.7z"/>
+			<path class="st1" d="M268.9,166.2c-6.1-11.8-18.9-6.1-20.9,8.5c-9,63.4,17.3,140,57.3,153.3c34.2,11.4,60.9-2.4,68.9-9.6
+				c9.8-8.8,4.2-17-3-21.5C316.9,261.3,290.2,207.7,268.9,166.2z"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
This patch implements page of UI and script for handling share link of banana browser.
If the banana browser share link url is included in parameter is passed,
page will display icon of banana browser in shortime and move the
current page to share link.