### PR TITLE
Implement banana browser sharelink

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,7 +4,7 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-<div class="bannerContainer" (click)="onBannerClicked()">
+<div class="bannerContainer" (click)="navigate()">
   <div class="bannerContent">
     <div class="bannerIconShadow">
       <svg width="0" height="0">

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,15 +3,75 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { TestBed } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
+import { AppComponent } from './app.component'
+import { TestCommon } from './test/testCommon'
 
 describe('AppComponent', () => {
+  // NOTE: If location.href change, can not run test any more,
+  // In other hands, location.href is not configurable so that could not mock the href by spyOnProperty
+  // so here use fakeLocation
+  const fakeLocation = {
+    href: ""
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
         AppComponent
       ],
-    }).compileComponents();
+      providers: [
+        { provide: 'Location', useValue: fakeLocation }
+      ]
+    }).compileComponents()
   });
-});
+
+  it('should display icon and description', fakeAsync(() => {
+    // given
+    const shareUrl = "https://google.com"
+    fakeLocation.href = TestCommon.generateTestShareLink(shareUrl)
+
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    tick()
+
+    TestCommon.mockUserAgent(TestCommon.USER_AGENT_ANDROID_WEB_VIEW)
+
+    // when
+    app.ngOnInit()
+    fixture.detectChanges()
+
+    // then
+    const icon = fixture.debugElement.query(By.css(".bannerIconLarge"))
+    expect(icon.nativeElement).toBeDefined()
+    const description = fixture.debugElement.query(By.css(".bannerDescription"))
+    expect(description.nativeElement.textContent.trim()).toEqual(app.DEFAULT_BANNER_DESCRIPTION)
+
+    tick(500)
+  }));
+
+  it('should display click banner if sharelink not navigated', fakeAsync(() => {
+    // given
+    const shareUrl = "https://google.com"
+    fakeLocation.href = TestCommon.generateTestShareLink(shareUrl)
+
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    tick(300)
+
+    TestCommon.mockUserAgent(TestCommon.USER_AGENT_ANDROID_CHROME_BROWSER)
+
+    // when
+    app.ngOnInit()
+    fixture.detectChanges()
+    tick(500)
+    fixture.detectChanges()
+
+    // then
+    const icon = fixture.debugElement.query(By.css(".bannerIconLarge"))
+    expect(icon.nativeElement).toBeDefined()
+    const description = fixture.debugElement.query(By.css(".bannerDescription"))
+    expect(description.nativeElement.textContent.trim()).toEqual(app.ANDROID_CHROME_CLICK_DESCRIPTION)
+  }));
+})

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core'
+import { ShareLink } from './shareUrl/sharelink-url'
+import { BrowserFactory } from './browser/browser-factory'
+import { Navigator as ShareLinkNavigator } from './navigator/navigator'
 
 @Component({
   selector: 'app-root',
@@ -11,15 +14,47 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent implements OnInit {
+  readonly TRIPLE_BANANA_DEV_URL = "https://triplebanana.dev"
+
   readonly DEFAULT_BANNER_DESCRIPTION: string = "Safer, faster, and more stable"
+  readonly ANDROID_CHROME_CLICK_DESCRIPTION = "Click to open link with Banana browser"
+
   bannerDescription = this.DEFAULT_BANNER_DESCRIPTION
 
-  ngOnInit(): void {
-    // Parse parameters as url and move
+  private shareLink: ShareLink
+  private navigator = new ShareLinkNavigator(this.location)
+
+  constructor(
+    @Inject('Location') private location: Location
+  ) {
+    this.shareLink = this.getShareLinkUrl()
   }
 
-  onBannerClicked() {
-    // If browser is chromium based,
-    // it is allowed to move only when user click action
+  ngOnInit(): void {
+    this.processShareLink()
+  }
+
+  navigate() {
+    const browser = BrowserFactory.getBrowser(this.navigator)
+    browser.navigate(this.shareLink)
+  }
+
+  private processShareLink() {
+    if (!this.shareLink.getUrl()) {
+      console.error("Failed to parse banana link : "
+        + this.location.href.toString())
+      this.location.href = this.TRIPLE_BANANA_DEV_URL
+      return
+    }
+
+    this.navigate()
+
+    setTimeout(() => {
+      this.bannerDescription = this.ANDROID_CHROME_CLICK_DESCRIPTION
+    }, 500)
+  }
+
+  private getShareLinkUrl(): ShareLink {
+    return new ShareLink(this.location.href)
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,7 +15,9 @@ import { AppComponent } from './app.component';
   imports: [
     BrowserModule
   ],
-  providers: [],
+  providers: [
+    { provide: 'Location', useValue: window.location }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/browser/android-browser.spec.ts
+++ b/src/app/browser/android-browser.spec.ts
@@ -1,0 +1,50 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { fakeAsync, tick } from '@angular/core/testing'
+import { Navigator } from '../navigator/navigator';
+import { ShareLink } from '../shareUrl/sharelink-url';
+import { TestCommon } from '../test/testCommon';
+import { AndroidBrowser } from './android-browser';
+
+describe('AndroidBrowser', () => {
+  const fakeLocation = {
+    href: ""
+  }
+
+  it('should navigate android intent including target url using shareUrl', fakeAsync(() => {
+    // given
+    const navigator = new Navigator(fakeLocation as Location)
+    const androidBrowser = new AndroidBrowser(navigator)
+
+    const shareLinkUrl = TestCommon.generateTestShareLink("https://google.com")
+
+    // There is no good way to check url has been navigated by iframe, so here spy on private method
+    const navigateWithIframe = spyOn<any>(androidBrowser, 'navigateWithIframe')
+      .and.callFake((url: string): void => console.log("do not move for test"))
+
+    // when
+    androidBrowser.navigate(new ShareLink(shareLinkUrl))
+    tick(300)
+
+    // then
+    expect(navigateWithIframe).toHaveBeenCalled()
+  }));
+
+  it('should navigate to playstore if not navigated to share link', fakeAsync(() => {
+    // given
+    const navigator = new Navigator(fakeLocation as Location)
+    const androidBrowser = new AndroidBrowser(navigator)
+
+    const shareLinkUrl = TestCommon.generateTestShareLink("https://google.com")
+
+    // when
+    androidBrowser.navigate(new ShareLink(shareLinkUrl))
+    tick(300)
+
+    // then
+    expect(fakeLocation.href).toEqual(AndroidBrowser.generatePlayStoreLinkUrl(AndroidBrowser.PACKAGE_ID))
+  }));
+})

--- a/src/app/browser/android-browser.ts
+++ b/src/app/browser/android-browser.ts
@@ -1,0 +1,44 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Browser } from "./browser";
+import { ShareLink } from '../shareUrl/sharelink-url';
+import { Navigator } from "../navigator/navigator";
+
+export class AndroidBrowser implements Browser {
+
+  static readonly PACKAGE_ID = "org.triple.banana"
+  static readonly PLAYSTORE_URL = "https://play.google.com/store/apps/details"
+
+  constructor(private navigator: Navigator) {
+  }
+
+  navigate(shareLink: ShareLink): void {
+    setTimeout(() => {
+      this.navigator.navigate(AndroidBrowser.generatePlayStoreLinkUrl(AndroidBrowser.PACKAGE_ID))
+    }, 300)
+    this.navigateWithIframe(shareLink)
+  }
+
+  static generateAndroidIntent(scheme: string, url: string, packageId: string): string {
+    return `intent://${url}#Intent;scheme=${scheme};package=${packageId};S.browser_fallback_url=${url};action=android.intent.action.VIEW;end;`
+  }
+
+  static generatePlayStoreLinkUrl(packageId: string): string {
+    return `https://play.google.com/store/apps/details?id=${packageId}`
+  }
+
+  private navigateWithIframe(shareLink: ShareLink): void {
+    const iframe = document.createElement('iframe')
+    iframe.style.visibility = 'hidden'
+    iframe.src = AndroidBrowser.generateAndroidIntent(
+        shareLink.getProtocol(),
+        shareLink.getUrlWithoutProtocol(),
+        AndroidBrowser.PACKAGE_ID
+    )
+    document.body.appendChild(iframe);
+    document.body.removeChild(iframe);
+  }
+}

--- a/src/app/browser/android-chrome-browser.spec.ts
+++ b/src/app/browser/android-chrome-browser.spec.ts
@@ -1,0 +1,39 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Navigator } from '../navigator/navigator';
+import { ShareLink } from '../shareUrl/sharelink-url';
+import { TestCommon } from '../test/testCommon';
+import { AndroidBrowser } from './android-browser';
+import { AndroidChromeBrowser } from './android-chrome-browser';
+
+describe('AndroidChromeBrowser', () => {
+
+  const fakeLocation = {
+    href: ""
+  }
+
+  it('should navigate android intent including target url using shareUrl', (() => {
+    // given
+    const navigator = new Navigator(fakeLocation as Location)
+    const androidBrowser = new AndroidChromeBrowser(navigator)
+
+    const shareLinkUrl = "https://google.com"
+    const shareLink = new ShareLink(TestCommon.generateTestShareLink(shareLinkUrl))
+
+    // when
+    androidBrowser.navigate(shareLink)
+
+    // then
+    const calledIntent = fakeLocation.href
+    const splittedIntent = calledIntent.split(';')
+    expect(splittedIntent[0]).toEqual(`intent://${new URL(shareLinkUrl).host}#Intent`)
+    expect(splittedIntent[1]).toEqual(`scheme=https`)
+    expect(splittedIntent[2]).toEqual(`package=${AndroidBrowser.PACKAGE_ID}`)
+    expect(splittedIntent[3]).toEqual(`S.browser_fallback_url=${new URL(shareLinkUrl).host}`)
+    expect(splittedIntent[4]).toEqual(`action=android.intent.action.VIEW`)
+    expect(splittedIntent[5]).toEqual(`end`)
+  }));
+})

--- a/src/app/browser/android-chrome-browser.ts
+++ b/src/app/browser/android-chrome-browser.ts
@@ -1,0 +1,24 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Browser } from "./browser";
+import { ShareLink } from '../shareUrl/sharelink-url';
+import { AndroidBrowser } from "./android-browser";
+import { Navigator } from "../navigator/navigator";
+
+export class AndroidChromeBrowser extends AndroidBrowser implements Browser {
+
+  constructor(private _navigator: Navigator) {
+    super(_navigator)
+  }
+
+  override navigate(shareLink: ShareLink): void {
+    this._navigator.navigate(AndroidBrowser.generateAndroidIntent(
+      shareLink.getProtocol(),
+      shareLink.getUrlWithoutProtocol(),
+      AndroidBrowser.PACKAGE_ID
+    ))
+  }
+}

--- a/src/app/browser/browser-factory.spec.ts
+++ b/src/app/browser/browser-factory.spec.ts
@@ -1,0 +1,35 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Navigator } from '../navigator/navigator';
+import { TestCommon } from '../test/testCommon';
+import { BrowserFactory } from './browser-factory';
+
+describe('BrowserFactory', () => {
+
+  it('should return android chrome browser types', (() => {
+    TestCommon.mockUserAgent(TestCommon.USER_AGENT_ANDROID_CHROME_BROWSER)
+
+    const browser = BrowserFactory.getBrowser(new Navigator(location))
+
+    expect(browser.constructor.name).toEqual('AndroidChromeBrowser')
+  }));
+
+  it('should return android browser types', (() => {
+    TestCommon.mockUserAgent(TestCommon.USER_AGENT_ANDROID_WEB_VIEW)
+
+    const browser = BrowserFactory.getBrowser(new Navigator(location))
+
+    expect(browser.constructor.name).toEqual('AndroidBrowser')
+  }));
+
+  it('should return default browser types', (() => {
+    TestCommon.mockUserAgent(TestCommon.USER_AGENT_LINUX_CHROME)
+
+    const browser = BrowserFactory.getBrowser(new Navigator(location))
+
+    expect(browser.constructor.name).toEqual('DefaultBrowser')
+  }));
+})

--- a/src/app/browser/browser-factory.ts
+++ b/src/app/browser/browser-factory.ts
@@ -1,0 +1,29 @@
+import { AndroidChromeBrowser } from "./android-chrome-browser";
+import { AndroidBrowser } from "./android-browser";
+import { DefaultBrowser } from "./default-browser";
+import { Browser } from "./browser";
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Navigator } from "../navigator/navigator";
+
+export class BrowserFactory {
+
+  static getBrowser(navigator: Navigator): Browser {
+    const userAgent = this.getUserAgent();
+    if (userAgent.match(/Android/)) {
+      if (userAgent.match(/Chrome/)) {
+        return new AndroidChromeBrowser(navigator)
+      } else {
+        return new AndroidBrowser(navigator)
+      }
+    }
+    return new DefaultBrowser(navigator)
+  }
+
+  private static getUserAgent(): string {
+    return navigator.userAgent
+  }
+}

--- a/src/app/browser/browser.ts
+++ b/src/app/browser/browser.ts
@@ -1,0 +1,10 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { ShareLink } from "../shareUrl/sharelink-url";
+
+export interface Browser {
+  navigate(shareLink: ShareLink): void
+}

--- a/src/app/browser/default-browser.spec.ts
+++ b/src/app/browser/default-browser.spec.ts
@@ -1,0 +1,31 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Navigator } from '../navigator/navigator';
+import { ShareLink } from '../shareUrl/sharelink-url';
+import { TestCommon } from '../test/testCommon';
+import { DefaultBrowser } from './default-browser';
+
+describe('DefaultBrowser', () => {
+
+  const fakeLocation = {
+    href: ""
+  }
+
+  it('should navigate shareLink url', (() => {
+    // given
+    const navigator = new Navigator(fakeLocation as Location)
+    const defaultBrowser = new DefaultBrowser(navigator)
+
+    const shareLinkUrl = "https://google.com"
+    const shareLink = new ShareLink(TestCommon.generateTestShareLink(shareLinkUrl))
+
+    // when
+    defaultBrowser.navigate(shareLink)
+
+    // then
+    expect(fakeLocation.href).toEqual(shareLinkUrl)
+  }));
+})

--- a/src/app/browser/default-browser.ts
+++ b/src/app/browser/default-browser.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Browser } from "./browser";
+import { ShareLink } from '../shareUrl/sharelink-url';
+import { Navigator } from "../navigator/navigator";
+
+export class DefaultBrowser implements Browser {
+
+  constructor(private navigator: Navigator) {
+  }
+
+  navigate(shareLink: ShareLink): void {
+    this.navigator.navigate(shareLink.getUrl())
+  }
+}

--- a/src/app/navigator/navigator.ts
+++ b/src/app/navigator/navigator.ts
@@ -1,0 +1,13 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export class Navigator {
+  constructor(private location: Location) {
+  }
+
+  navigate(url: string) {
+    this.location.href = url
+  }
+}

--- a/src/app/shareUrl/sharelink-url.spec.ts
+++ b/src/app/shareUrl/sharelink-url.spec.ts
@@ -1,0 +1,36 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { ShareLink } from './sharelink-url'
+
+describe('ShareLink', () => {
+  it('should parse share link', () => {
+    const bananaShareLink = "https://triplebanana.dev?sharelink=https://www.google.co.kr/imghp?hl=ko&ogbl"
+    const shareLink = new ShareLink(bananaShareLink)
+
+    expect(shareLink.getUrl()).toEqual("https://www.google.co.kr/imghp?hl=ko&ogbl")
+    expect(shareLink.getProtocol()).toEqual("https")
+    expect(shareLink.getUrlWithoutProtocol()).toEqual("www.google.co.kr/imghp?hl=ko&ogbl")
+  })
+
+  it('should return empty url if not contain sharelink url', () => {
+    const notContainedShareUrl = "https://www.google.co.kr/imghp?hl=ko&ogbl"
+    const shareLink = new ShareLink(notContainedShareUrl)
+
+    expect(shareLink.getUrl()).toEqual("")
+    expect(shareLink.getProtocol()).toEqual("")
+    expect(shareLink.getUrlWithoutProtocol()).toEqual("")
+  })
+
+  it('should return proper scheme', () => {
+    const notContainedShareUrl = "https://triplebanana.dev?sharelink=http://www.google.co.kr"
+    const shareLink = new ShareLink(notContainedShareUrl)
+
+    expect(shareLink.getUrl()).toEqual("http://www.google.co.kr")
+    expect(shareLink.getProtocol()).toEqual("http")
+    expect(shareLink.getUrlWithoutProtocol()).toEqual("www.google.co.kr")
+  })
+
+})

--- a/src/app/shareUrl/sharelink-url.ts
+++ b/src/app/shareUrl/sharelink-url.ts
@@ -1,0 +1,44 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export class ShareLink {
+  static readonly SHARE_LINK_PARAM = "?sharelink="
+
+  private protocol: string = ""
+  private shareUrl: string = ""
+  private urlWithoutProtocol: string = ""
+
+  constructor(bananaShareUrl: string) {
+    const shareLink = this.parseShareLink(bananaShareUrl)
+    if (!shareLink) return
+
+    this.shareUrl = shareLink
+    this.protocol = this.parseProtocol(shareLink)
+    this.urlWithoutProtocol = this.shareUrl.replace(this.protocol+"://", "")
+  }
+
+  getUrl(): string {
+    return this.shareUrl
+  }
+
+  getProtocol(): string {
+    return this.protocol
+  }
+
+  getUrlWithoutProtocol(): string {
+    return this.urlWithoutProtocol
+  }
+
+  private parseShareLink(fullUrl: string): string {
+    const shareLinkIndex = fullUrl.indexOf(ShareLink.SHARE_LINK_PARAM)
+    if (shareLinkIndex === -1) return ""
+
+    return fullUrl.substring(shareLinkIndex + ShareLink.SHARE_LINK_PARAM.length)
+  }
+
+  private parseProtocol(shareLinkUrl: string): string {
+    return shareLinkUrl.startsWith("https") ? "https" : "http"
+  }
+}

--- a/src/app/test/testCommon.ts
+++ b/src/app/test/testCommon.ts
@@ -1,0 +1,28 @@
+// Copyright 2022 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export class TestCommon {
+  static readonly USER_AGENT_ANDROID_CHROME_BROWSER =
+    "Mozilla/5.0 (Linux; Android 12; SM-G996N) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Mobile Safari/537.36"
+
+  static readonly USER_AGENT_ANDROID_WEB_VIEW =
+    "Mozilla/5.0 (Android; Mobile; rv:13.0) \
+    Gecko/13.0 Firefox/13.0"
+
+  static readonly USER_AGENT_LINUX_CHROME =
+    "Mozilla/5.0 (X11; Linux x86_64) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"
+
+  static readonly TRIPLE_BANANA_SHARE_URL = "https://triplebanana.dev/share"
+
+  static generateTestShareLink(url: string) {
+    return `${TestCommon.TRIPLE_BANANA_SHARE_URL}?sharelink=${url}`
+  }
+
+  static mockUserAgent(userAgent: string) {
+    spyOnProperty(navigator, 'userAgent').and.returnValue(userAgent)
+  }
+}


### PR DESCRIPTION
This patch implements scripts for handling
share link of banana browser.

Because banana browser only support android,
Running platform is not android,
move shared url directly using current browser.

If android and banana browser is not installed,
provide banana browser installation suggestion.
Once banana browser is installed, move link thorugh banana browser